### PR TITLE
Update dump_apis script

### DIFF
--- a/demo/client/dump_apis.sh
+++ b/demo/client/dump_apis.sh
@@ -1,11 +1,3 @@
 #!/usr/bin/env bash
 
-# Make a directory with interfaces
-generated_interfaces="$(pwd)/generated_interfaces"
-echo "Creating output dir:  ${generated_interfaces}"
-mkdir -p $generated_interfaces
-
-# Dump the gRPC interfaces (using caikit as configured)
-cd ../..
-echo "Using caikit.runtime.dump_services to get interfaces"
-RUNTIME_LIBRARY=caikit_embeddings python -m caikit.runtime.dump_services $generated_interfaces
+RUNTIME_LIBRARY=caikit_nlp caikit-render-interfaces /tmp/generated_interfaces


### PR DESCRIPTION
* Runtime library is now in caikit_nlp
* Leverage caikit-render-interfaces
* Put output in /tmp for container perms

This script is no longer needed because it is a single command, but updating it while it helps for docs (and migration?).