### PR TITLE
Update caikit-nlp requirement to use caikit/caikit-nlp pinned SHA

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-caikit-nlp[sentence-transformers]@git+https://github.com/markstur/caikit-nlp@embedding_prs
-sentence-transformers
+caikit-nlp[sentence-transformers]@git+https://github.com/caikit/caikit-nlp@ba76d56853e0ed87e985d10fce63137521a8505c
+sentence-transformers>=2.2.2,<2.3.0
 


### PR DESCRIPTION
* Not using markstur fork repo anymore for the caikit or caikit-nlp code